### PR TITLE
Ensure server dimension is stored as an integer

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -28,6 +28,10 @@ try:
     with open(config_file, "r") as cfg:
         config = DictObject(hjson.load(cfg))
 
+    # ensure dimension is integer
+    if isinstance(config.server.dimension, str):
+        config.server.dimension = int(config.server.dimension)
+
     if platform.system() == "Windows":
         os.system("title %s.%d" % (config.character, config.server.dimension))
 


### PR DESCRIPTION
Hi guys, had an issue where the config was storing the dimension as a string, subsequently this was throwing a lot of issues on string formats later on.

Put in a quick check to convert to int if detected as string for review - new to python so there may be a better way.

