### PR TITLE
Discord online formatting

### DIFF
--- a/modules/standard/online/online_controller.py
+++ b/modules/standard/online/online_controller.py
@@ -181,7 +181,7 @@ class OnlineController:
             current_main = ""
 
             # store maximum string lengths, these will be used to space the result table
-            max_lengths = [0, 0, 0, 0]
+            max_lengths = [0, 0, 0, 0, 0]
 
             # hold values for rendering later
             online_list_processed = []
@@ -191,16 +191,17 @@ class OnlineController:
                 # increment count based on mains only
                 if current_main != row.main:
                     count += 1
+                    processed = [row.main, "", "", "", ""]
+                    online_list_processed.append(processed)
                     current_main = row.main
-
                 # create array of 'processed' character information
                 processed = [
-                    row.name,
-                    "(%d/%d)" % (row.level or 0, row.ai_level or 0),
-                    row.faction,
-                    row.profession
+                    " | ",
+                    "{:12}".format(row.name),
+                    "({:3}".format(row.level or 0)+"/"+"{:2})".format(row.ai_level or 0),
+                    "{:7}".format(row.faction),
+                    "{:15}".format(row.profession)
                 ]
-
                 # append to other array for iteration later
                 online_list_processed.append(processed)
 
@@ -214,21 +215,20 @@ class OnlineController:
                         max_lengths[i] = length
             
             # start content with channel name, start monospace
-            blob += "\n[%s]\n```" % channel
+            blob += "\n[%s]\n```apache\n" % channel
 
             # increment max lengths for spacing
             for i in range(len(max_lengths)):
                 max_lengths[i] += 1
 
             # iterate processed characters and add to content
-            for row in online_list_processed:
-                for i in range(len(max_lengths)):
-                    blob += row[i].ljust(max_lengths[i])
-                
+            for character in online_list_processed:
+                for attribute in character:
+                    blob += attribute + " "
                 # append newline
                 blob += "\n"
 
-            # end monospace
+            # end monospaced
             blob += "```"
 
         if not blob:

--- a/modules/standard/online/online_controller.py
+++ b/modules/standard/online/online_controller.py
@@ -168,69 +168,28 @@ class OnlineController:
         blob = ""
         count = 0
 
-        # iterate channels
         for channel in [self.ORG_CHANNEL, self.PRIVATE_CHANNEL]:
-            # get characters
+            # get characters, if none are online skip this channel
             online_list = self.get_online_characters(channel)
-
-            # if no characters, skip this channel
             if len(online_list) == 0:
                 continue
 
-            # used to keep track of the current main
+            # start content with channel name, start monospaced (```)
+            blob += "\n[%s]\n```yaml\n" % channel
             current_main = ""
-
-            # store maximum string lengths, these will be used to space the result table
-            max_lengths = [0, 0, 0, 0, 0]
-
-            # hold values for rendering later
-            online_list_processed = []
-
-            # iterate online players in this channel
-            for row in online_list:
-                # increment count based on mains only
-                if current_main != row.main:
+            for character in online_list:
+                # add main character line
+                if current_main != character.main:
                     count += 1
-                    processed = [row.main, "", "", "", ""]
-                    online_list_processed.append(processed)
-                    current_main = row.main
-                # create array of 'processed' character information
-                processed = [
-                    " | ",
-                    "{:12}".format(row.name),
-                    "({:3}".format(row.level or 0)+"/"+"{:2})".format(row.ai_level or 0),
-                    "{:7}".format(row.faction),
-                    "{:15}".format(row.profession)
-                ]
-                # append to other array for iteration later
-                online_list_processed.append(processed)
-
-                # iterate character information
-                for i in range(len(processed)):
-                    # get length of this piece of information
-                    length = len(processed[i])
-
-                    # if length exceeds existing max, assign
-                    if length > max_lengths[i]:
-                        max_lengths[i] = length
-            
-            # start content with channel name, start monospace
-            blob += "\n[%s]\n```apache\n" % channel
-
-            # increment max lengths for spacing
-            for i in range(len(max_lengths)):
-                max_lengths[i] += 1
-
-            # iterate processed characters and add to content
-            for character in online_list_processed:
-                for attribute in character:
-                    blob += attribute + " "
-                # append newline
-                blob += "\n"
-
-            # end monospaced
+                    current_main = character.main
+                    blob += character.main + ": \n"
+                # add online character line
+                character_line = " | " + ("{:13} ".format(character.name)) + "({:3}".format(
+                    character.level or 0) + "/" + "{:2}) ".format(character.ai_level or 0) + "{:7} ".format(
+                    character.faction) + "{:15} \n".format(character.profession)
+                blob += character_line
+            # end monospaced content
             blob += "```"
-
         if not blob:
             blob = "No characters online."
 


### PR DESCRIPTION
resolve #25 

Online command now has fixed column sizes. All columns are spaced from each other with a single space.

column sizes:
- 13 for character names 
  - is maximum name length in AO
- 3 for level
- 2 for ai level
- 7 for side
  - 'neutral'
- 15 for profession
  - to fit 'nano technician'

Also now groups by mains like the in-game command does
Pretty colors bonus

example:
![image](https://user-images.githubusercontent.com/11883404/56137996-3b87cf00-5f96-11e9-90a9-7bd04a1c7515.png)
