### PR TITLE
can now add a (optional) reason to the restart and shutdown commands

### DIFF
--- a/modules/core/system/system_controller.py
+++ b/modules/core/system/system_controller.py
@@ -1,3 +1,4 @@
+from core.command_param_types import Any
 from core.decorators import instance, command, event, setting
 from core.command_service import CommandService
 from core.dict_object import DictObject
@@ -10,8 +11,9 @@ from core.setting_types import BooleanSettingType
 class SystemController:
     SHUTDOWN_EVENT = "shutdown"
 
-    shutdown_msg = "The bot is shutting down..."
-    restart_msg = "The bot is restarting..."
+    shutdown_msg = "The bot is shutting down."
+    restart_msg = "The bot is restarting."
+    reason_msg = " <highlight>Reason: {}<end>"
 
     def __init__(self):
         self.logger = Logger(__name__)
@@ -32,21 +34,27 @@ class SystemController:
     def restart_notify(self):
         return BooleanSettingType()
 
-    @command(command="shutdown", params=[], access_level="superadmin",
+    @command(command="shutdown", params=[Any("reason", is_optional=True)], access_level="superadmin",
              description="Shutdown the bot")
-    def shutdown_cmd(self, request):
+    def shutdown_cmd(self, request, reason):
         if request.channel not in [CommandService.ORG_CHANNEL, CommandService.PRIVATE_CHANNEL]:
-            request.reply(self.shutdown_msg)
+            if reason:
+                request.reply(self.shutdown_msg + self.reason_msg.format(reason))
+            else:
+                request.reply(self.shutdown_msg + "..")
 
-        self.shutdown(False)
+        self.shutdown(False, reason)
 
-    @command(command="restart", params=[], access_level="admin",
+    @command(command="restart", params=[Any("reason", is_optional=True)], access_level="admin",
              description="Restart the bot")
-    def restart_cmd(self, request):
+    def restart_cmd(self, request, reason):
         if request.channel not in [CommandService.ORG_CHANNEL, CommandService.PRIVATE_CHANNEL]:
-            request.reply(self.restart_msg)
+            if reason:
+                request.reply(self.restart_msg + self.reason_msg.format(reason))
+            else:
+                request.reply(self.restart_msg + "..")
 
-        self.shutdown(True)
+        self.shutdown(True, reason)
 
     @event(event_type="connect", description="Notify superadmin that bot has come online")
     def connect_event(self, event_type, event_data):
@@ -65,23 +73,33 @@ class SystemController:
     @event(event_type=SHUTDOWN_EVENT, description="Notify org channel on shutdown/restart")
     def notify_org_channel_shutdown_event(self, event_type, event_data):
         if event_data.restart:
-            self.bot.send_org_message(self.restart_msg, fire_outgoing_event=False)
+            if event_data.reason:
+                self.bot.send_org_message(self.restart_msg + self.reason_msg.format(event_data.reason), fire_outgoing_event=False)
+            else:
+                self.bot.send_org_message(self.restart_msg + "..", fire_outgoing_event=False)
         else:
-            self.bot.send_org_message(self.shutdown_msg, fire_outgoing_event=False)
+            if event_data.reason:
+                self.bot.send_org_message(self.shutdown_msg + self.reason_msg.format(event_data.reason), fire_outgoing_event=False)
+            else:
+                self.bot.send_org_message(self.shutdown_msg + "..", fire_outgoing_event=False)
 
     @event(event_type=SHUTDOWN_EVENT, description="Notify private channel on shutdown/restart")
     def notify_private_channel_shutdown_event(self, event_type, event_data):
         if event_data.restart:
-            self.bot.send_private_channel_message(self.restart_msg, fire_outgoing_event=False)
+            if event_data.reason:
+                self.bot.send_private_channel_message(self.restart_msg + self.reason_msg.format(event_data.reason), fire_outgoing_event=False)
+            else:
+                self.bot.send_private_channel_message(self.restart_msg + "..", fire_outgoing_event=False)
         else:
-            self.bot.send_private_channel_message(self.shutdown_msg, fire_outgoing_event=False)
+            if event_data.reason:
+                self.bot.send_private_channel_message(self.shutdown_msg + self.reason_msg.format(event_data.reason), fire_outgoing_event=False)
+            else:
+                self.bot.send_private_channel_message(self.shutdown_msg + "..", fire_outgoing_event=False)
 
-    def shutdown(self, should_restart):
-        self.event_service.fire_event(self.SHUTDOWN_EVENT, DictObject({"restart": should_restart}))
-
+    def shutdown(self, should_restart, reason = None):
+        self.event_service.fire_event(self.SHUTDOWN_EVENT, DictObject({"restart": should_restart, "reason": reason}))
         # set expected flag
         self.expected_shutdown().set_value(True)
-
         if should_restart:
             self.bot.restart()
         else:


### PR DESCRIPTION
resolves #53 

Added optional reason parameter to shutdown and restart commands
Updated existing events to send reason if one was set