### PR TITLE
Add --skip-install option to start.bat

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,11 +1,13 @@
 @echo off
 
-IF EXIST .\venv\ GOTO start
+IF EXIST .\venv\ GOTO install
 .\win32\Python3.6\python.exe -m virtualenv --python=.\win32\Python3.6\python.exe venv
 
-:start
+:install
+IF [%1] == [--skip-install] GOTO run
 venv\Scripts\pip install -U -r requirements.txt
 
+:run
 venv\Scripts\python ./bootstrap.py
 
 REM The bot uses non-zero exit codes to signal state.
@@ -13,7 +15,7 @@ REM The bot will restart until it returns an exit code of zero.
 if %errorlevel% == 0 goto end
 
 timeout /t 1
-goto :start
+goto :install
 
 :end
 pause


### PR DESCRIPTION
Adds a cmd line option (`skip-install`) which will not run pip install (saves time and spam when restarting the server)