### PR TITLE
docker support for linux/arm64 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV PYTHONPATH=/app/deps
 
 RUN apt update && apt upgrade -y
 
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then apt-get -y install gcc; fi
+
 RUN adduser --no-create-home --disabled-login --disabled-password --shell /bin/false --gecos "" --uid 1001 user && \
     mkdir /app && \
     chown user:user /app


### PR DESCRIPTION
on `linux/arm64` building the docker image fails, because `pip` wants to compile `psutils` from source, which fails because `gcc` is not installed.
```
#6 109.9       building 'psutil._psutil_linux' extension
#6 109.9       creating build/temp.linux-aarch64-cpython-311
#6 109.9       creating build/temp.linux-aarch64-cpython-311/psutil
#6 109.9       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=596 -DPy_LIMITED_API=0x03060000 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -DPSUTIL_LINUX=1 -I/usr/local/include/python3.11 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-cpython-311/psutil/_psutil_common.o
#6 109.9       psutil could not be installed from sources because gcc is not installed. Try running:
#6 109.9         sudo apt-get install gcc python3-dev
#6 109.9       error: command 'gcc' failed: No such file or directory
```

this change installs `gcc` only on the `linux/arm64` target platform and thus `psutils` and the docker image build succeeds

adding support for `linux/arm64` means, that people can host their bots for example on a Raspberry Pi 4