### PR TITLE
Avoid unnecessary use of eval (insecure)

### DIFF
--- a/core/aochat/crypt.py
+++ b/core/aochat/crypt.py
@@ -43,7 +43,7 @@ def generate_login_key(server_key, username, password):
     if len(dhK) > 32:
         dhK = dhK[:32]
 
-    dhK = eval("0x" + dhK)
+    dhK = int(dhK, 16)
 
     challenge = "%s|%s|%s" % (username, server_key, password)
 


### PR DESCRIPTION
The appropriate way to convert a hexadecimal string to integer is by using the built-in functionality of `int`. The `eval` function is insecure; if the input could possibly come from outside the program, no matter how indirectly, this creates a risk of an arbitrary code execution exploit. It's also much less efficient.